### PR TITLE
Update Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,17 @@
-# Add your own tasks in files placed in lib/tasks ending in .rake, for example
-# lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 require_relative 'config/application'
 
-Rails.application.load_tasks
+ENV['RUBYOPT'] = '-W0'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+  t.rspec_opts = '--format documentation'
+  t.verbose = false
+end
+
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
+end
+
+task default: [:spec, :rubocop]


### PR DESCRIPTION
Running `rake` will now:
  * Run all rspec tests verbosely
  * Run rubocop
  * Hide all warnings (e.g. Fixnum deprecation warnings)