### PR TITLE
LVM-434: Implement basic user auth gating

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -223,26 +223,26 @@ span.tag {
 }
 
 .chosen-container-multi .chosen-choices li.search-choice {
-    position: relative;
-    margin: 3px 5px 3px 0;
-    padding: 5px 25px 5px 10px;
-    border: none;
-    max-width: 100%;
-    border-radius: 10px;
-    background-color: #8882d8;
-    background-image: none;
-    background-size: 100% 19px;
-    box-shadow: none;
-    color: white;
-    line-height: 13px;
-    cursor: default;
+  position: relative;
+  margin: 3px 5px 3px 0;
+  padding: 5px 25px 5px 10px;
+  border: none;
+  max-width: 100%;
+  border-radius: 10px;
+  background-color: #8882d8;
+  background-image: none;
+  background-size: 100% 19px;
+  box-shadow: none;
+  color: white;
+  line-height: 13px;
+  cursor: default;
 }
 
 .chosen-container-multi .chosen-choices li.search-choice .search-choice-close {
-    top: 4px;
-    background: none;
-    font-size: 16px;
-    color: #dcdcdc;
+  top: 4px;
+  background: none;
+  font-size: 16px;
+  color: #dcdcdc;
 }
 
 .chosen-container-multi .chosen-choices li.search-choice .search-choice-close::before {

--- a/app/controllers/affiliates_controller.rb
+++ b/app/controllers/affiliates_controller.rb
@@ -1,5 +1,6 @@
 class AffiliatesController < ApplicationController
   before_action :set_affiliate, only: [:show, :edit, :update, :destroy]
+  before_action :ensure_admin!
 
   # GET /affiliates
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+
+  def ensure_coordinator_or_admin!
+    deny_access unless current_user.coordinator? || current_user.admin?
+  end
+
+  def ensure_admin!
+    deny_access unless current_user.admin?
+  end
+
+  private
+
+  def deny_access
+    flash[:alert] = 'Access Denied'
+    redirect_to root_path
+  end
 end

--- a/app/controllers/coordinators_controller.rb
+++ b/app/controllers/coordinators_controller.rb
@@ -1,4 +1,6 @@
 class CoordinatorsController < ApplicationController
+  before_action :ensure_admin!
+
   def index
     @coordinators = Coordinator.all
   end
@@ -58,11 +60,15 @@ class CoordinatorsController < ApplicationController
 
   def students
     match_params = { coordinator_id: params[:id], end: nil }
-    Enrollment.where(match_params).to_a.map { |e| Student.find(e.student_id) }
+    Enrollment.where(match_params).to_a.map do |e|
+      Student.of(current_user).find(e.student_id)
+    end
   end
 
   def tutors
     match_params = { coordinator_id: params[:id], end: nil }
-    VolunteerJob.where(match_params).to_a.map { |v| Tutor.find(v.tutor_id) }
+    VolunteerJob.where(match_params).to_a.map do |v|
+      Tutor.of(current_user).find(v.tutor_id)
+    end
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,5 +1,6 @@
 class TagsController < ApplicationController
   before_action :set_tag, only: [:show, :edit, :update, :destroy]
+  before_action :ensure_coordinator_or_admin!, only: [:index, :show]
 
   def index
     @tags = Tag.all
@@ -7,11 +8,11 @@ class TagsController < ApplicationController
 
   def show
     @tagged_students = Tagging.where(tag_id: @tag.id, tutor_id: nil).map do |t|
-      Student.find(t.student_id)
+      Student.of(current_user).find(t.student_id)
     end
 
     @tagged_tutors = Tagging.where(tag_id: @tag.id, student_id: nil).map do |t|
-      Tutor.find(t.tutor_id)
+      Tutor.of(current_user).find(t.tutor_id)
     end
 
     respond_to do |format|

--- a/app/controllers/tutor_comments_controller.rb
+++ b/app/controllers/tutor_comments_controller.rb
@@ -3,7 +3,7 @@ class TutorCommentsController < ApplicationController
 
   def new
     @tutor_comment = TutorComment.new
-    @tutor = Tutor.find(params[:tutor])
+    @tutor = Tutor.of(current_user).find(params[:tutor])
   end
 
   def create
@@ -12,26 +12,26 @@ class TutorCommentsController < ApplicationController
     if @tutor_comment.save
       redirect_to tutor_path(tutor_comment_params[:tutor_id])
     else
-      @tutor = Tutor.find(tutor_comment_params[:tutor_id])
+      @tutor = Tutor.of(current_user).find(tutor_comment_params[:tutor_id])
       render :new
     end
   end
 
   def edit
-    @tutor = Tutor.find(@tutor_comment.tutor_id)
+    @tutor = Tutor.of(current_user).find(@tutor_comment.tutor_id)
   end
 
   def update
     if @tutor_comment.update(tutor_comment_params)
       redirect_to tutor_path(tutor_comment_params[:tutor_id])
     else
-      @tutor = Tutor.find(tutor_comment_params[:tutor_id])
+      @tutor = Tutor.of(current_user).find(tutor_comment_params[:tutor_id])
       render :edit
     end
   end
 
   def destroy
-    @tutor = Tutor.find(@tutor_comment.tutor_id)
+    @tutor = Tutor.of(current_user).find(@tutor_comment.tutor_id)
     @tutor_comment.destroy
 
     redirect_to tutor_path(@tutor)

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,3 +1,8 @@
 class WelcomeController < ApplicationController
-  def index; end
+  def index
+    @see_students = current_user.role > 0
+    @see_tutors = current_user.role > 0
+    @see_coordinators = current_user.role == 2
+    @see_affiliates = current_user.role == 2
+  end
 end

--- a/app/models/coordinator.rb
+++ b/app/models/coordinator.rb
@@ -2,6 +2,8 @@ class Coordinator < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   VALID_PHONE_REGEX = /\A\([0-9]{3}\) [0-9]{3}-[0-9]{4}\z/
 
+  belongs_to :user
+
   has_many :enrollments
   has_many :students, through: :enrollments
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -5,22 +5,22 @@ class Student < ApplicationRecord
   VALID_SMARTT_REGEX = /\A[0-9]{4}-[0-9]{6}\z/
   LAST_NAME_ID_REGEX = /\A[0-9]{4,5}\z/
 
-  has_many :matches
-  has_many :tutors, through: :matches
+  has_many :affiliates
+  has_many :assessments
 
   has_many :enrollments
   has_many :coordinators, through: :enrollments
-  has_many :assessments
 
-  has_many :affiliates
-  # has_many :student_comments
+  has_many :matches
+  has_many :tutors, through: :matches
 
   has_many :taggings
   has_many :tags, through: :taggings
 
   validates :first_name, presence: true
-  validates :last_name, presence: true
   validates :gender, presence: true
+  validates :last_name, presence: true
+
   validates :cell_phone,   format: { with: VALID_PHONE_REGEX },
                            allow_blank: true
   validates :home_phone,   format: { with: VALID_PHONE_REGEX },
@@ -80,5 +80,15 @@ class Student < ApplicationRecord
             ('warning' if warning.include? status) ||
             ('danger'  if danger.include? status)
     klass
+  end
+
+  def self.of(user)
+    if user.coordinator?
+      joins(:enrollments).where(
+        enrollments: { coordinator_id: user.coordinator_id }
+      )
+    elsif user.admin?
+      all
+    end
   end
 end

--- a/app/models/tutor.rb
+++ b/app/models/tutor.rb
@@ -5,6 +5,8 @@ class Tutor < ApplicationRecord
   VALID_SMARTT_REGEX = /\A[0-9]{4}-[0-9]{6}\z/
   LAST_NAME_ID_REGEX = /\A[0-9]{4,5}\z/
 
+  belongs_to :user
+
   has_many :matches
   has_many :students, through: :matches
 
@@ -103,5 +105,15 @@ class Tutor < ApplicationRecord
             ('warning' if warning.include? status) ||
             ('danger'  if danger.include? status)
     klass
+  end
+
+  def self.of(user)
+    if user.coordinator?
+      joins(:volunteer_jobs).where(
+        volunteer_jobs: { coordinator_id: user.coordinator_id }
+      )
+    elsif user.admin?
+      all
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,12 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
+  has_one :coordinator
+  has_one :tutor
+
+  validate :single_account_type
   validates_numericality_of :role, in: 0..2
 
-  # Role management as follows
-  # 0 => tutor (default)
-  # 1 => coordinator
-  # 2 => admin
   def tutor?
     role.zero?
   end
@@ -22,11 +22,8 @@ class User < ApplicationRecord
     role == 2
   end
 
-  def coordinator_level?
-    role >= 1
-  end
-
-  def admin_level?
-    role >= 2
+  def single_account_type
+    return unless coordinator_id && tutor_id
+    errors.add(:account_type, "Can't be tutor and coordinator")
   end
 end

--- a/app/views/affiliates/index.html.erb
+++ b/app/views/affiliates/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <div class="row index-header">
   <div class="col-md-12 title">
     Affiliates

--- a/app/views/coordinators/index.html.erb
+++ b/app/views/coordinators/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <div class="row index-header">
   <div class="col-md-12 title">
     Coordinators

--- a/app/views/students/edit.html.erb
+++ b/app/views/students/edit.html.erb
@@ -25,13 +25,11 @@
         <span class="h4">Edit Student</span>
       </div>
     </div>
-    
+
     <hr>
 
     <%= simple_form_for :student, url: student_path(@student), method: :patch do |f| %>
-
       <%= render partial: 'form', locals: {f: f} %>
-
     <% end %>
 
   </div>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -1,8 +1,6 @@
-<p id="notice"><%= notice %></p>
-
 <div class="row index-header">
   <div class="col-md-12 title">
-    Students
+    <span> Students </span>
   </div>
 </div>
 
@@ -43,8 +41,8 @@
   </tbody>
 </table>
 
-<%= link_to 'Home', root_path %> |
-<%= link_to 'New Student', new_student_path %>
+<%= link_to 'Home', root_path %>
+<% if @show_new_student_link %> | <%= link_to 'New Student', new_student_path %> <% end %>
 
 <script>
 // Because turbolinks gets the page from the cache instead of making another

--- a/app/views/tutors/index.html.erb
+++ b/app/views/tutors/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <div class="row index-header">
   <div class="col-md-12 title">
     Tutors

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,18 +4,28 @@
   </div>
 
   <div class='row centered'>
-    <div class='col-md-2 text-center'>
-      <%= link_to 'Students', { controller: 'students' }, class: 'button' %>
-    </div>
-    <div class='col-md-2 text-center'>
-      <%= link_to 'Tutors', { controller: 'tutors' }, class: 'button' %>
-    </div>
+    <% if @see_students %>
+      <div class='col-md-2 text-center'>
+        <%= link_to 'Students', { controller: 'students' }, class: 'button' %>
+      </div>
+    <% end %>
 
-    <div class='col-md-2 text-center'>
-      <%= link_to 'Coordinators', { controller: 'coordinators' }, class: 'button' %>
-    </div>
-    <div class='col-md-2 text-center'>
-      <%= link_to 'Affiliates', { controller: 'affiliates' }, class: 'button' %>
-    </div>
+    <% if @see_tutors %>
+      <div class='col-md-2 text-center'>
+        <%= link_to 'Tutors', { controller: 'tutors' }, class: 'button' %>
+      </div>
+    <% end %>
+
+    <% if @see_coordinators %>
+      <div class='col-md-2 text-center'>
+        <%= link_to 'Coordinators', { controller: 'coordinators' }, class: 'button' %>
+      </div>
+    <% end %>
+
+    <% if @see_affiliates %>
+      <div class='col-md-2 text-center'>
+        <%= link_to 'Affiliates', { controller: 'affiliates' }, class: 'button' %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/db/fixtures/coordinators.rb
+++ b/db/fixtures/coordinators.rb
@@ -1,4 +1,4 @@
-20.times do
+13.times do
   Coordinator.seed do |c|
     c.first_name = Faker::Name.first_name
     c.last_name = Faker::Name.last_name

--- a/db/fixtures/enrollments.rb
+++ b/db/fixtures/enrollments.rb
@@ -1,10 +1,9 @@
-students = [*1..20].shuffle
-coordinators = [*1..20].shuffle
+students = [*1..100].shuffle
 
-15.times do
+100.times do
   Enrollment.seed do |e|
     e.student_id = students.pop
-    e.coordinator_id = coordinators.pop
+    e.coordinator_id = [1, 2].sample
     e.start = Date.today
   end
 end

--- a/db/fixtures/matches.rb
+++ b/db/fixtures/matches.rb
@@ -1,10 +1,9 @@
 students = [*1..20].shuffle
-tutors = [*1..20].shuffle
 
 15.times do
   Match.seed do |m|
     m.student_id = students.pop
-    m.tutor_id = tutors.pop
+    m.tutor_id = [1, 2].sample
     m.start = Date.today
   end
 end

--- a/db/fixtures/students.rb
+++ b/db/fixtures/students.rb
@@ -1,4 +1,4 @@
-20.times do
+100.times do
   Student.seed do |s|
     s.first_name = Faker::Name.first_name
     s.last_name  = Faker::Name.last_name

--- a/db/fixtures/tutors.rb
+++ b/db/fixtures/tutors.rb
@@ -1,7 +1,7 @@
 require 'application_helper'
 require 'tutors_helper'
 
-20.times do
+100.times do
   Tutor.seed do |t|
     t.address1                = Faker::Address.street_address
     t.address2                = Faker::Address.secondary_address

--- a/db/fixtures/users.rb
+++ b/db/fixtures/users.rb
@@ -1,6 +1,5 @@
 User.seed(
-  :id,
-  { id: 1, role: 0, email: 'tutor@email.com', password: 'password', password_confirmation: 'password' },
-  { id: 2, role: 1, email: 'coordinator@email.com', password: 'password', password_confirmation: 'password' },
+  { id: 1, role: 0, email: 'tutor@email.com', password: 'password', password_confirmation: 'password', tutor_id: 1 },
+  { id: 2, role: 1, email: 'coordinator@email.com', password: 'password', password_confirmation: 'password', coordinator_id: 1 },
   { id: 3, role: 2, email: 'admin@email.com', password: 'password', password_confirmation: 'password' }
 )

--- a/db/fixtures/volunteer_jobs.rb
+++ b/db/fixtures/volunteer_jobs.rb
@@ -1,10 +1,9 @@
-tutors = [*1..20].shuffle
-coordinators = [*1..20].shuffle
+tutors = [*1..100].shuffle
 
-15.times do
+100.times do
   VolunteerJob.seed do |v|
     v.tutor_id = tutors.pop
-    v.coordinator_id = coordinators.pop
+    v.coordinator_id = rand(13) + 1
     v.start = Date.today
   end
 end

--- a/db/migrate/20170326005240_user_tutors_and_coordinators.rb
+++ b/db/migrate/20170326005240_user_tutors_and_coordinators.rb
@@ -1,0 +1,6 @@
+class UserTutorsAndCoordinators < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :tutor_id, :integer
+    add_column :users, :coordinator_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,6 +257,8 @@ ActiveRecord::Schema.define(version: 20170403194336) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.integer  "role",                   default: 0
+    t.integer  "tutor_id"
+    t.integer  "coordinator_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/affiliates_controller_spec.rb
+++ b/spec/controllers/affiliates_controller_spec.rb
@@ -1,163 +1,175 @@
 require 'rails_helper'
 
 RSpec.describe AffiliatesController, type: :controller do
-  describe 'endpoints' do
-    before do
-      sign_in_auth
+  describe 'as not admin' do
+    it 'redirects to root path' do
+      user = User.new(role: 1)
+      sign_in_auth(user)
+      get :index
+      expect(response).to redirect_to(root_path)
     end
+  end
 
-    describe 'GET #index' do
-      it 'populates an array of all affiliate' do
-        affiliates = [create(:affiliate)]
-        get :index
-        expect(assigns(:affiliates)).to eq(affiliates)
-      end
-
-      it 'renders the :index view' do
-        get :index
-        expect(response).to render_template :index
-      end
-    end
-
-    describe 'GET #show' do
+  describe 'as admin' do
+    describe 'endpoints' do
       before do
-        @affiliate = create(:affiliate)
+        user = User.new(role: 2)
+        sign_in_auth(user)
       end
 
-      it 'populates the specified affiliate' do
-        get :show, params: { id: @affiliate }
-        expect(assigns(:affiliate)).to eq(@affiliate)
-      end
-
-      it 'renders the :show view' do
-        get :show, params: { id: @affiliate }
-        expect(response).to render_template :show
-      end
-    end
-
-    describe 'GET #new' do
-      it 'populates a new affiliate' do
-        get :new
-        expect(assigns(:affiliate)).to be_a_new(Affiliate)
-      end
-
-      it 'renders the :new view' do
-        get :new
-        expect(response).to render_template :new
-      end
-    end
-
-    describe 'GET #edit' do
-      before do
-        @affiliate = create(:affiliate)
-      end
-      it 'populates the specific student' do
-        get :edit, params: { id: @affiliate }
-        expect(assigns(:affiliate)).to eq(@affiliate)
-      end
-
-      it 'render the :edit view' do
-        get :edit, params: { id: @affiliate }
-        expect(response).to render_template :edit
-      end
-    end
-
-    describe 'POST #create' do
-      before do
-        @affiliate_attrs = attributes_for(:affiliate)
-      end
-
-      context 'with valid attributes' do
-        it 'saved the new affiliate in the database' do
-          post :create, params: { affiliate: @affiliate_attrs }
-          expect(assigns(:affiliate)).to be_persisted
+      describe 'GET #index' do
+        it 'populates an array of all affiliate' do
+          affiliates = [create(:affiliate)]
+          get :index
+          expect(assigns(:affiliates)).to eq(affiliates)
         end
 
-        it 'assigns the newly created affiliate as @affiliate' do
-          post :create, params: { affiliate: @affiliate_attrs }
-          expect(assigns(:affiliate)).to be_a(Affiliate)
-        end
-
-        it 'redirects to the newly created affiliate view' do
-          post :create, params: { affiliate: @affiliate_attrs }
-          expect(response).to redirect_to(Affiliate.last)
+        it 'renders the :index view' do
+          get :index
+          expect(response).to render_template :index
         end
       end
 
-      context 'with invalid attributes' do
+      describe 'GET #show' do
         before do
-          allow_any_instance_of(Affiliate).to receive(:save) { false }
+          @affiliate = create(:affiliate)
         end
 
-        it 'assigns a newly created but unsaved affiliate as @affiliate' do
-          post :create, params: { affiliate: @affiliate_attrs }
-          expect(assigns(:affiliate)).to be_a_new(Affiliate)
-        end
-
-        it 're-renders the :new view' do
-          post :create, params: { affiliate: @affiliate_attrs }
-          expect(response).to render_template :new
-        end
-      end
-    end
-
-    describe 'PUT #update' do
-      before do
-        @affiliate = create(:affiliate)
-        @new_affiliate_attrs = attributes_for(:affiliate)
-      end
-
-      context 'with valid attributes' do
-        it 'saves the new affiliate in the database' do
-          post :update, params: { id: @affiliate,
-                                  affiliate: @new_affiliate_attrs }
-          expect(Affiliate.last.name).to eq(@new_affiliate_attrs[:name])
-        end
-
-        it 'assigns the updated affiliate as @affiliate' do
-          post :update, params: { id: @affiliate,
-                                  affiliate: @new_affiliate_attrs }
-          expect(assigns(:affiliate).name)
-            .to eq(@new_affiliate_attrs[:name])
-        end
-
-        it 'redirects to the affiliate view' do
-          post :update, params: { id: @affiliate,
-                                  affiliate: @new_affiliate_attrs }
-          expect(response).to redirect_to(@affiliate)
-        end
-      end
-
-      context 'with invalid attributes' do
-        before do
-          allow_any_instance_of(Affiliate).to receive(:update) { false }
-        end
-
-        it 'assigns the existing affiliate as @affiliate' do
-          post :update, params: { id: @affiliate,
-                                  affiliate: @new_affiliate_attrs }
+        it 'populates the specified affiliate' do
+          get :show, params: { id: @affiliate }
           expect(assigns(:affiliate)).to eq(@affiliate)
         end
 
-        it 're-renders the :edit view' do
-          post :update, params: { id: @affiliate,
-                                  affiliate: @new_affiliate_attrs }
+        it 'renders the :show view' do
+          get :show, params: { id: @affiliate }
+          expect(response).to render_template :show
+        end
+      end
+
+      describe 'GET #new' do
+        it 'populates a new affiliate' do
+          get :new
+          expect(assigns(:affiliate)).to be_a_new(Affiliate)
+        end
+
+        it 'renders the :new view' do
+          get :new
+          expect(response).to render_template :new
+        end
+      end
+
+      describe 'GET #edit' do
+        before do
+          @affiliate = create(:affiliate)
+        end
+        it 'populates the specific student' do
+          get :edit, params: { id: @affiliate }
+          expect(assigns(:affiliate)).to eq(@affiliate)
+        end
+
+        it 'render the :edit view' do
+          get :edit, params: { id: @affiliate }
           expect(response).to render_template :edit
         end
       end
-    end
 
-    describe 'DELETE #destroy' do
-      it 'destroys the affiliate' do
-        affiliate = create(:affiliate)
-        expect { delete :destroy, params: { id: affiliate } }
-          .to change(Affiliate, :count).by(-1)
+      describe 'POST #create' do
+        before do
+          @affiliate_attrs = attributes_for(:affiliate)
+        end
+
+        context 'with valid attributes' do
+          it 'saved the new affiliate in the database' do
+            post :create, params: { affiliate: @affiliate_attrs }
+            expect(assigns(:affiliate)).to be_persisted
+          end
+
+          it 'assigns the newly created affiliate as @affiliate' do
+            post :create, params: { affiliate: @affiliate_attrs }
+            expect(assigns(:affiliate)).to be_a(Affiliate)
+          end
+
+          it 'redirects to the newly created affiliate view' do
+            post :create, params: { affiliate: @affiliate_attrs }
+            expect(response).to redirect_to(Affiliate.last)
+          end
+        end
+
+        context 'with invalid attributes' do
+          before do
+            allow_any_instance_of(Affiliate).to receive(:save) { false }
+          end
+
+          it 'assigns a newly created but unsaved affiliate as @affiliate' do
+            post :create, params: { affiliate: @affiliate_attrs }
+            expect(assigns(:affiliate)).to be_a_new(Affiliate)
+          end
+
+          it 're-renders the :new view' do
+            post :create, params: { affiliate: @affiliate_attrs }
+            expect(response).to render_template :new
+          end
+        end
       end
 
-      it 'redirects to the :index view' do
-        affiliate = create(:affiliate)
-        delete :destroy, params: { id: affiliate }
-        expect(response).to redirect_to affiliates_path
+      describe 'PUT #update' do
+        before do
+          @affiliate = create(:affiliate)
+          @new_affiliate_attrs = attributes_for(:affiliate)
+        end
+
+        context 'with valid attributes' do
+          it 'saves the new affiliate in the database' do
+            post :update, params: { id: @affiliate,
+                                    affiliate: @new_affiliate_attrs }
+            expect(Affiliate.last.name).to eq(@new_affiliate_attrs[:name])
+          end
+
+          it 'assigns the updated affiliate as @affiliate' do
+            post :update, params: { id: @affiliate,
+                                    affiliate: @new_affiliate_attrs }
+            expect(assigns(:affiliate).name)
+              .to eq(@new_affiliate_attrs[:name])
+          end
+
+          it 'redirects to the affiliate view' do
+            post :update, params: { id: @affiliate,
+                                    affiliate: @new_affiliate_attrs }
+            expect(response).to redirect_to(@affiliate)
+          end
+        end
+
+        context 'with invalid attributes' do
+          before do
+            allow_any_instance_of(Affiliate).to receive(:update) { false }
+          end
+
+          it 'assigns the existing affiliate as @affiliate' do
+            post :update, params: { id: @affiliate,
+                                    affiliate: @new_affiliate_attrs }
+            expect(assigns(:affiliate)).to eq(@affiliate)
+          end
+
+          it 're-renders the :edit view' do
+            post :update, params: { id: @affiliate,
+                                    affiliate: @new_affiliate_attrs }
+            expect(response).to render_template :edit
+          end
+        end
+      end
+
+      describe 'DELETE #destroy' do
+        it 'destroys the affiliate' do
+          affiliate = create(:affiliate)
+          expect { delete :destroy, params: { id: affiliate } }
+            .to change(Affiliate, :count).by(-1)
+        end
+
+        it 'redirects to the :index view' do
+          affiliate = create(:affiliate)
+          delete :destroy, params: { id: affiliate }
+          expect(response).to redirect_to affiliates_path
+        end
       end
     end
   end

--- a/spec/controllers/coordinator_controller_spec.rb
+++ b/spec/controllers/coordinator_controller_spec.rb
@@ -1,179 +1,191 @@
 require 'rails_helper'
 
 RSpec.describe CoordinatorsController, type: :controller do
-  describe 'endpoints' do
-    before do
-      sign_in_auth
+  describe 'as not admin' do
+    it 'redirects to root path' do
+      user = User.new(role: 1)
+      sign_in_auth(user)
+      get :index
+      expect(response).to redirect_to(root_path)
     end
+  end
 
-    describe 'GET #index' do
+  describe 'as admin' do
+    describe 'endpoints' do
       before do
-        @coordinator = create(:full_coordinator)
+        user = User.new(role: 2)
+        sign_in_auth(user)
       end
 
-      it 'populates the specified coordinator' do
-        get :show, params: { id: @coordinator }
-        expect(assigns(:coordinator)).to eq(@coordinator)
-      end
-
-      it 'renders the :index view' do
-        get :index
-        expect(response).to render_template :index
-      end
-    end
-
-    describe 'GET #show' do
-      before do
-        @coordinator = create(:full_coordinator)
-      end
-
-      it 'populates the specified coordinator' do
-        get :show, params: { id: @coordinator }
-        expect(assigns(:coordinator)).to eq(@coordinator)
-      end
-
-      it "populates the specified coordinator's students" do
-        get :show, params: { id: @coordinator }
-        expect(assigns(:students)).to eq(@coordinator.students)
-      end
-
-      it "populates the specified coordinator's tutors" do
-        get :show, params: { id: @coordinator }
-        expect(assigns(:tutors)).to eq(@coordinator.tutors)
-      end
-
-      it 'renders the :show view' do
-        get :show, params: { id: @coordinator }
-        expect(response).to render_template :show
-      end
-    end
-
-    describe 'GET #new' do
-      it 'populates a new coordinator' do
-        get :new
-        expect(assigns(:coordinator)).to be_a_new(Coordinator)
-      end
-
-      it 'renders the :new view' do
-        get :new
-        expect(response).to render_template :new
-      end
-    end
-
-    describe 'GET #edit' do
-      before do
-        @coordinator = create(:coordinator)
-      end
-
-      it 'populates the specified coordinator' do
-        get :edit, params: { id: @coordinator }
-        expect(assigns(:coordinator)).to eq(@coordinator)
-      end
-
-      it 'renders the :edit view' do
-        get :edit, params: { id: @coordinator }
-        expect(response).to render_template :edit
-      end
-    end
-
-    describe 'POST #create' do
-      before do
-        @coordinator_attrs = attributes_for(:coordinator)
-      end
-
-      context 'with valid attributes' do
-        it 'saves the new coordinator in the database' do
-          post :create, params: { coordinator: @coordinator_attrs }
-          expect(assigns(:coordinator)).to be_persisted
-        end
-
-        it 'assigns the newly created coordinator as @coordinator' do
-          post :create, params: { coordinator: @coordinator_attrs }
-          expect(assigns(:coordinator)).to be_a(Coordinator)
-        end
-
-        it 'redirects to the newly created coordinator view' do
-          post :create, params: { coordinator: @coordinator_attrs }
-          expect(response).to redirect_to(Coordinator.last)
-        end
-      end
-
-      context 'with invalid attributes' do
+      describe 'GET #index' do
         before do
-          allow_any_instance_of(Coordinator).to receive(:save) { false }
+          @coordinator = create(:full_coordinator)
         end
 
-        it 'assigns a newly created but unsaved purchase as @purchase' do
-          post :create, params: { coordinator: @coordinator_attrs }
-          expect(assigns(:coordinator)).to be_a_new(Coordinator)
-        end
-
-        it 're-renders the :new view' do
-          post :create, params: { coordinator: @coordinator_attrs }
-          expect(response).to render_template :new
-        end
-      end
-    end
-
-    describe 'PUT #update' do
-      before do
-        @coordinator = create(:coordinator)
-        @new_coordinator_attrs = attributes_for(:coordinator)
-      end
-
-      context 'with valid attributes' do
-        it 'saves the new coordinator in the database' do
-          post :update, params: { id: @coordinator.id,
-                                  coordinator: @new_coordinator_attrs }
-          expect(Coordinator.last.first_name)
-            .to eq(@new_coordinator_attrs[:first_name])
-        end
-
-        it 'assigns the updated coordinator as @coordinator' do
-          post :update, params: { id: @coordinator.id,
-                                  coordinator: @new_coordinator_attrs }
-          expect(assigns(:coordinator).first_name)
-            .to eq(@new_coordinator_attrs[:first_name])
-        end
-
-        it 'redirects to the coordinator view' do
-          post :update, params: { id: @coordinator.id,
-                                  coordinator: @new_coordinator_attrs }
-          expect(response).to redirect_to(@coordinator)
-        end
-      end
-
-      context 'with invalid attributes' do
-        before do
-          allow_any_instance_of(Coordinator).to receive(:update) { false }
-        end
-
-        it 'assigns the existing coordinator as @coordinator' do
-          post :update, params: {
-            id: @coordinator, coordinator: @new_coordinator_attrs
-          }
+        it 'populates the specified coordinator' do
+          get :show, params: { id: @coordinator }
           expect(assigns(:coordinator)).to eq(@coordinator)
         end
 
-        it 're-renders the :edit view' do
-          post :update, params: {
-            id: @coordinator, coordinator: @new_coordinator_attrs
-          }
+        it 'renders the :index view' do
+          get :index
+          expect(response).to render_template :index
+        end
+      end
+
+      describe 'GET #show' do
+        before do
+          @coordinator = create(:full_coordinator)
+        end
+
+        it 'populates the specified coordinator' do
+          get :show, params: { id: @coordinator }
+          expect(assigns(:coordinator)).to eq(@coordinator)
+        end
+
+        it "populates the specified coordinator's students" do
+          get :show, params: { id: @coordinator }
+          expect(assigns(:students)).to eq(@coordinator.students)
+        end
+
+        it "populates the specified coordinator's tutors" do
+          get :show, params: { id: @coordinator }
+          expect(assigns(:tutors)).to eq(@coordinator.tutors)
+        end
+
+        it 'renders the :show view' do
+          get :show, params: { id: @coordinator }
+          expect(response).to render_template :show
+        end
+      end
+
+      describe 'GET #new' do
+        it 'populates a new coordinator' do
+          get :new
+          expect(assigns(:coordinator)).to be_a_new(Coordinator)
+        end
+
+        it 'renders the :new view' do
+          get :new
+          expect(response).to render_template :new
+        end
+      end
+
+      describe 'GET #edit' do
+        before do
+          @coordinator = create(:coordinator)
+        end
+
+        it 'populates the specified coordinator' do
+          get :edit, params: { id: @coordinator }
+          expect(assigns(:coordinator)).to eq(@coordinator)
+        end
+
+        it 'renders the :edit view' do
+          get :edit, params: { id: @coordinator }
           expect(response).to render_template :edit
         end
       end
-    end
 
-    describe 'DELETE #destroy' do
-      it 'destroys the coordinator' do
-        coordinator = create(:coordinator)
-        expect { delete :destroy, params: { id: coordinator } }
-          .to change(Coordinator, :count).by(-1)
+      describe 'POST #create' do
+        before do
+          @coordinator_attrs = attributes_for(:coordinator)
+        end
+
+        context 'with valid attributes' do
+          it 'saves the new coordinator in the database' do
+            post :create, params: { coordinator: @coordinator_attrs }
+            expect(assigns(:coordinator)).to be_persisted
+          end
+
+          it 'assigns the newly created coordinator as @coordinator' do
+            post :create, params: { coordinator: @coordinator_attrs }
+            expect(assigns(:coordinator)).to be_a(Coordinator)
+          end
+
+          it 'redirects to the newly created coordinator view' do
+            post :create, params: { coordinator: @coordinator_attrs }
+            expect(response).to redirect_to(Coordinator.last)
+          end
+        end
+
+        context 'with invalid attributes' do
+          before do
+            allow_any_instance_of(Coordinator).to receive(:save) { false }
+          end
+
+          it 'assigns a newly created but unsaved purchase as @purchase' do
+            post :create, params: { coordinator: @coordinator_attrs }
+            expect(assigns(:coordinator)).to be_a_new(Coordinator)
+          end
+
+          it 're-renders the :new view' do
+            post :create, params: { coordinator: @coordinator_attrs }
+            expect(response).to render_template :new
+          end
+        end
       end
-      it 'redirects to the :index view' do
-        coordinator = create(:coordinator)
-        delete :destroy, params: { id: coordinator }
-        expect(response).to redirect_to coordinators_path
+
+      describe 'PUT #update' do
+        before do
+          @coordinator = create(:coordinator)
+          @new_coordinator_attrs = attributes_for(:coordinator)
+        end
+
+        context 'with valid attributes' do
+          it 'saves the new coordinator in the database' do
+            post :update, params: { id: @coordinator.id,
+                                    coordinator: @new_coordinator_attrs }
+            expect(Coordinator.last.first_name)
+              .to eq(@new_coordinator_attrs[:first_name])
+          end
+
+          it 'assigns the updated coordinator as @coordinator' do
+            post :update, params: { id: @coordinator.id,
+                                    coordinator: @new_coordinator_attrs }
+            expect(assigns(:coordinator).first_name)
+              .to eq(@new_coordinator_attrs[:first_name])
+          end
+
+          it 'redirects to the coordinator view' do
+            post :update, params: { id: @coordinator.id,
+                                    coordinator: @new_coordinator_attrs }
+            expect(response).to redirect_to(@coordinator)
+          end
+        end
+
+        context 'with invalid attributes' do
+          before do
+            allow_any_instance_of(Coordinator).to receive(:update) { false }
+          end
+
+          it 'assigns the existing coordinator as @coordinator' do
+            post :update, params: {
+              id: @coordinator, coordinator: @new_coordinator_attrs
+            }
+            expect(assigns(:coordinator)).to eq(@coordinator)
+          end
+
+          it 're-renders the :edit view' do
+            post :update, params: {
+              id: @coordinator, coordinator: @new_coordinator_attrs
+            }
+            expect(response).to render_template :edit
+          end
+        end
+      end
+
+      describe 'DELETE #destroy' do
+        it 'destroys the coordinator' do
+          coordinator = create(:coordinator)
+          expect { delete :destroy, params: { id: coordinator } }
+            .to change(Coordinator, :count).by(-1)
+        end
+        it 'redirects to the :index view' do
+          coordinator = create(:coordinator)
+          delete :destroy, params: { id: coordinator }
+          expect(response).to redirect_to coordinators_path
+        end
       end
     end
   end

--- a/spec/controllers/student_controller_spec.rb
+++ b/spec/controllers/student_controller_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe StudentsController, type: :controller do
-  before do
-    sign_in_auth
-  end
-
   describe 'helpers' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
+    end
+
     describe '#tutor_options' do
       it 'populates a list of available tutors' do
         @t = create(:tutor)
@@ -16,20 +17,73 @@ RSpec.describe StudentsController, type: :controller do
 
   describe 'endpoints' do
     describe 'GET #index' do
-      it 'populates an array of all students' do
-        students = [create(:student)]
-        get :index
-        expect(assigns(:students)).to eq(students)
+      before do
+        create(:affiliate, id: 1)
+
+        create(:tutor, affiliate_id: 1, id: 1)
+
+        create(:coordinator, affiliate_id: 1, id: 1)
+
+        create(:student, id: 1)
+        create(:student, id: 2)
+
+        Student.find(1).coordinators << Coordinator.find(1)
+
+        @all_students = [Student.find(1), Student.find(2)]
+        @coordinator_students = [Student.find(1)]
       end
 
-      it 'renders the :index view' do
-        get :index
-        expect(response).to render_template :index
+      describe 'as admin' do
+        before do
+          user = User.new(role: 2)
+          sign_in_auth(user)
+        end
+
+        it 'populates an array of all students' do
+          get :index
+          expect(assigns(:students)).to eq(@all_students)
+        end
+
+        it 'renders the :index view' do
+          get :index
+          expect(response).to render_template :index
+        end
+      end
+
+      describe 'as coordinator' do
+        before do
+          user = User.new(role: 1, coordinator_id: 1)
+          sign_in_auth(user)
+        end
+
+        it 'populates an array of all students' do
+          get :index
+          expect(assigns(:students)).to eq(@coordinator_students)
+        end
+
+        it 'renders the :index view' do
+          get :index
+          expect(response).to render_template :index
+        end
+      end
+
+      describe 'as tutor' do
+        before do
+          user = User.new(role: 0, tutor_id: 1)
+          sign_in_auth(user)
+        end
+
+        it 'redirects to the welcome view' do
+          get :index
+          expect(response).to redirect_to root_path
+        end
       end
     end
 
     describe 'GET #show' do
       before do
+        user = User.new(role: 2)
+        sign_in_auth(user)
         @student = create(:full_student)
       end
 
@@ -55,244 +109,269 @@ RSpec.describe StudentsController, type: :controller do
         expect(response).to render_template :show
       end
     end
+  end
 
-    describe 'GET #new' do
-      it 'populates a new student' do
-        get :new
+  describe 'GET #new' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
+    end
+
+    it 'populates a new student' do
+      get :new
+      expect(assigns(:student)).to be_a_new(Student)
+    end
+
+    it 'renders the :new view' do
+      get :new
+      expect(response).to render_template :new
+    end
+  end
+
+  describe 'GET #edit' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
+      @student = create(:student)
+    end
+
+    it 'populates the specified student' do
+      get :edit, params: { id: @student }
+      expect(assigns(:student)).to eq(@student)
+    end
+
+    it 'renders the :edit view' do
+      get :edit, params: { id: @student }
+      expect(response).to render_template :edit
+    end
+  end
+
+  describe 'POST #create' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
+      @student_attrs = attributes_for(:student)
+    end
+
+    context 'with valid attributes' do
+      it 'saves the new student in the database' do
+        post :create, params: { student: @student_attrs }
+        expect(assigns(:student)).to be_persisted
+      end
+
+      it 'assigns the newly created student as @student' do
+        post :create, params: { student: @student_attrs }
+        expect(assigns(:student)).to be_a(Student)
+      end
+
+      it 'redirects to the newly created student view' do
+        post :create, params: { student: @student_attrs }
+        expect(response).to redirect_to(Student.last)
+      end
+    end
+
+    context 'with invalid attributes' do
+      before do
+        user = User.new(role: 2)
+        sign_in_auth(user)
+        allow_any_instance_of(Student).to receive(:save) { false }
+      end
+
+      it 'assigns a newly created but unsaved purchase as @purchase' do
+        post :create, params: { student: @student_attrs }
         expect(assigns(:student)).to be_a_new(Student)
       end
 
-      it 'renders the :new view' do
-        get :new
+      it 're-renders the :new view' do
+        post :create, params: { student: @student_attrs }
         expect(response).to render_template :new
       end
     end
+  end
 
-    describe 'GET #edit' do
-      before do
-        @student = create(:student)
+  describe 'PUT #update' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
+      @student = create(:student)
+      @new_student_attrs = attributes_for(:student)
+    end
+
+    context 'with valid attributes' do
+      it 'saves the new student in the database' do
+        post :update, params: { id: @student, student: @new_student_attrs }
+        expect(Student.last.first_name).to eq(@new_student_attrs[:first_name])
       end
 
-      it 'populates the specified student' do
-        get :edit, params: { id: @student }
+      it 'assigns the updated student as @student' do
+        post :update, params: { id: @student, student: @new_student_attrs }
+        expect(assigns(:student).first_name)
+          .to eq(@new_student_attrs[:first_name])
+      end
+
+      it 'redirects to the student view' do
+        post :update, params: { id: @student, student: @new_student_attrs }
+        expect(response).to redirect_to(@student)
+      end
+    end
+
+    context 'with invalid attributes' do
+      before do
+        user = User.new(role: 2)
+        sign_in_auth(user)
+        allow_any_instance_of(Student).to receive(:update) { false }
+      end
+
+      it 'assigns the existing student as @student' do
+        post :update, params: { id: @student, student: @new_student_attrs }
         expect(assigns(:student)).to eq(@student)
       end
 
-      it 'renders the :edit view' do
-        get :edit, params: { id: @student }
+      it 're-renders the :edit view' do
+        post :update, params: { id: @student, student: @new_student_attrs }
         expect(response).to render_template :edit
       end
     end
+  end
 
-    describe 'POST #create' do
-      before do
-        @student_attrs = attributes_for(:student)
-      end
-
-      context 'with valid attributes' do
-        it 'saves the new student in the database' do
-          post :create, params: { student: @student_attrs }
-          expect(assigns(:student)).to be_persisted
-        end
-
-        it 'assigns the newly created student as @student' do
-          post :create, params: { student: @student_attrs }
-          expect(assigns(:student)).to be_a(Student)
-        end
-
-        it 'redirects to the newly created student view' do
-          post :create, params: { student: @student_attrs }
-          expect(response).to redirect_to(Student.last)
-        end
-      end
-
-      context 'with invalid attributes' do
-        before do
-          allow_any_instance_of(Student).to receive(:save) { false }
-        end
-
-        it 'assigns a newly created but unsaved purchase as @purchase' do
-          post :create, params: { student: @student_attrs }
-          expect(assigns(:student)).to be_a_new(Student)
-        end
-
-        it 're-renders the :new view' do
-          post :create, params: { student: @student_attrs }
-          expect(response).to render_template :new
-        end
-      end
+  describe 'PATCH #update_tags' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
+      @student = create(:student)
+      @params = { id: @student.id, student: { 'all_tags' => ['', 'test'] } }
     end
 
-    describe 'PUT #update' do
-      before do
-        @student = create(:student)
-        @new_student_attrs = attributes_for(:student)
+    context 'with valid attributes' do
+      it 'updates the tags for a student' do
+        patch :update_tags, params: @params
+        expect(Student.last.tags).to eq([Tag.last])
+        expect(Tag.last.name).to eq 'test'
       end
 
-      context 'with valid attributes' do
-        it 'saves the new student in the database' do
-          post :update, params: { id: @student, student: @new_student_attrs }
-          expect(Student.last.first_name).to eq(@new_student_attrs[:first_name])
-        end
-
-        it 'assigns the updated student as @student' do
-          post :update, params: { id: @student, student: @new_student_attrs }
-          expect(assigns(:student).first_name)
-            .to eq(@new_student_attrs[:first_name])
-        end
-
-        it 'redirects to the student view' do
-          post :update, params: { id: @student, student: @new_student_attrs }
-          expect(response).to redirect_to(@student)
-        end
-      end
-
-      context 'with invalid attributes' do
-        before do
-          allow_any_instance_of(Student).to receive(:update) { false }
-        end
-
-        it 'assigns the existing student as @student' do
-          post :update, params: { id: @student, student: @new_student_attrs }
-          expect(assigns(:student)).to eq(@student)
-        end
-
-        it 're-renders the :edit view' do
-          post :update, params: { id: @student, student: @new_student_attrs }
-          expect(response).to render_template :edit
-        end
+      it 'redirects to the student view' do
+        post :update, params: @params
+        expect(response).to redirect_to(@student)
       end
     end
+  end
 
-    describe 'PATCH #update_tags' do
-      before do
-        @student = create(:student)
-        @params = { id: @student.id, student: { 'all_tags' => ['', 'test'] } }
-      end
-
-      context 'with valid attributes' do
-        it 'updates the tags for a student' do
-          patch :update_tags, params: @params
-          expect(Student.last.tags).to eq([Tag.last])
-          expect(Tag.last.name).to eq 'test'
-        end
-
-        it 'redirects to the student view' do
-          post :update, params: @params
-          expect(response).to redirect_to(@student)
-        end
-      end
+  describe 'DELETE #destroy' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
     end
+    it 'destroys the student' do
+      student = create(:student)
+      expect { delete :destroy, params: { id: student } }
+        .to change(Student, :count).by(-1)
+    end
+    it 'redirects to the :index view' do
+      student = create(:student)
+      delete :destroy, params: { id: student }
+      expect(response).to redirect_to students_path
+    end
+  end
 
-    describe 'DELETE #destroy' do
-      it 'destroys the student' do
+  describe 'PUT #set_tutor' do
+    before do
+      user = User.new(role: 2)
+      sign_in_auth(user)
+    end
+    context 'when tutor_id is zero' do
+      before do
+        @tutor_id = 0
+      end
+
+      it 'does not set up a new match for the student' do
         student = create(:student)
-        expect { delete :destroy, params: { id: student } }
-          .to change(Student, :count).by(-1)
+        put :set_tutor, params: { tutor_id: @tutor_id, student_id: student }
+        expect(Match.where(student_id: student, end: nil).length).to be(0)
       end
-      it 'redirects to the :index view' do
-        student = create(:student)
-        delete :destroy, params: { id: student }
-        expect(response).to redirect_to students_path
-      end
-    end
 
-    describe 'PUT #set_tutor' do
-      context 'when tutor_id is zero' do
-        before do
-          @tutor_id = 0
-        end
-
-        it 'does not set up a new match for the student' do
-          student = create(:student)
+      context 'when student has a tutor' do
+        it 'unmatches the current tutor' do
+          student = create(:matched_student)
+          tutor_id = Match.where(student_id: student).take.tutor_id
           put :set_tutor, params: { tutor_id: @tutor_id, student_id: student }
-          expect(Match.where(student_id: student, end: nil).length).to be(0)
+          expect(
+            Match.where(student_id: student, tutor_id: tutor_id).take.end
+          ).not_to eq(nil)
         end
+      end
+    end
 
-        context 'when student has a tutor' do
-          it 'unmatches the current tutor' do
-            student = create(:matched_student)
-            tutor_id = Match.where(student_id: student).take.tutor_id
-            put :set_tutor, params: { tutor_id: @tutor_id, student_id: student }
-            expect(
-              Match.where(student_id: student, tutor_id: tutor_id).take.end
-            ).not_to eq(nil)
-          end
+    context 'when tutor_id is nonzero' do
+      before do
+        @tutor = create(:tutor)
+      end
+
+      context 'when the student does not have a tutor' do
+        it 'matches the student with the specified tutor' do
+          student = create(:student)
+          put :set_tutor, params: { tutor_id: @tutor, student_id: student }
+          expect(
+            Match.where(student_id: student, tutor_id: @tutor).length
+          ).to eq(1)
         end
       end
 
-      context 'when tutor_id is nonzero' do
-        before do
-          @tutor = create(:tutor)
+      context 'when student has a tutor' do
+        before(:each) do
+          @student = create(:matched_student)
+          @old_tutor = Match.where(student_id: @student).take.tutor_id
         end
 
-        context 'when the student does not have a tutor' do
-          it 'matches the student with the specified tutor' do
-            student = create(:student)
-            put :set_tutor, params: { tutor_id: @tutor, student_id: student }
+        context "when specified tutor is student's current tutor" do
+          before do
+            @new_tutor = @old_tutor
+          end
+
+          it "does not unmatch the student's current tutor" do
+            put :set_tutor, params: {
+              tutor_id: @new_tutor, student_id: @student
+            }
             expect(
-              Match.where(student_id: student, tutor_id: @tutor).length
+              Match.where(
+                student_id: @student, tutor_id: @old_tutor, end: nil
+              ).length
             ).to eq(1)
           end
+
+          it 'does not set up a new match for the student' do
+            put :set_tutor, params: {
+              tutor_id: @new_tutor, student_id: @student
+            }
+            # That is, the student started with and ended with exactlt 1 match
+            expect(Match.where(student_id: @student).length).to eq(1)
+          end
         end
 
-        context 'when student has a tutor' do
-          before(:each) do
-            @student = create(:matched_student)
-            @old_tutor = Match.where(student_id: @student).take.tutor_id
+        context "when specified tutor is not student's current tutor" do
+          before do
+            @new_tutor = create(:tutor)
           end
 
-          context "when specified tutor is student's current tutor" do
-            before do
-              @new_tutor = @old_tutor
-            end
-
-            it "does not unmatch the student's current tutor" do
-              put :set_tutor, params: {
-                tutor_id: @new_tutor, student_id: @student
-              }
-              expect(
-                Match.where(
-                  student_id: @student, tutor_id: @old_tutor, end: nil
-                ).length
-              ).to eq(1)
-            end
-
-            it 'does not set up a new match for the student' do
-              put :set_tutor, params: {
-                tutor_id: @new_tutor, student_id: @student
-              }
-              # That is, the student started with and ended with exactlt 1 match
-              expect(Match.where(student_id: @student).length).to eq(1)
-            end
+          it "unmatches the student's current tutor" do
+            put :set_tutor, params: {
+              tutor_id: @new_tutor, student_id: @student
+            }
+            expect(
+              Match.where(
+                student_id: @student, tutor_id: @old_tutor, end: nil
+              ).length
+            ).to eq(0)
           end
 
-          context "when specified tutor is not student's current tutor" do
-            before do
-              @new_tutor = create(:tutor)
-            end
-
-            it "unmatches the student's current tutor" do
-              put :set_tutor, params: {
-                tutor_id: @new_tutor, student_id: @student
-              }
-              expect(
-                Match.where(
-                  student_id: @student, tutor_id: @old_tutor, end: nil
-                ).length
-              ).to eq(0)
-            end
-
-            it 'matches the student with the specified tutor' do
-              put :set_tutor, params: {
-                tutor_id: @new_tutor, student_id: @student
-              }
-              expect(
-                Match.where(
-                  student_id: @student, tutor_id: @new_tutor, end: nil
-                ).length
-              ).to eq(1)
-            end
+          it 'matches the student with the specified tutor' do
+            put :set_tutor, params: {
+              tutor_id: @new_tutor, student_id: @student
+            }
+            expect(
+              Match.where(
+                student_id: @student, tutor_id: @new_tutor, end: nil
+              ).length
+            ).to eq(1)
           end
         end
       end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,131 +1,144 @@
 require 'rails_helper'
 
 RSpec.describe TagsController, type: :controller do
-  describe 'endpoints' do
-    before do
-      sign_in_auth
+  describe 'as not coordinator' do
+    it 'redirects to root path' do
+      user = User.new(role: 0)
+      sign_in_auth(user)
+      get :index
+      expect(response).to redirect_to(root_path)
     end
+  end
 
-    describe 'GET #index' do
-      it 'populates an array of all tags' do
-        tags = [create(:tag)]
-        get :index
-        expect(assigns(:tags)).to eq(tags)
-      end
-
-      it 'renders the :index view' do
-        get :index
-        expect(response).to render_template :index
-      end
-    end
-
-    describe 'GET #show' do
+  describe 'as coordinator' do
+    describe 'endpoints' do
       before do
-        @tag = create(:tag)
-        @student = create(:student)
-        @tutor = create(:tutor)
-        Tagging.create(tag_id: @tag.id, student_id: @student.id)
-        Tagging.create(tag_id: @tag.id, tutor_id: @tutor.id)
+        user = User.new(role: 2)
+        sign_in_auth(user)
       end
 
-      it 'populates the tag, tutors, and students tagged' do
-        get :show, params: { id: @tag }, format: :js, xhr: true
-        expect(assigns(:tag)).to eq(@tag)
-        expect(assigns(:tagged_students)).to eq([@student])
-        expect(assigns(:tagged_tutors)).to eq([@tutor])
-      end
-    end
-
-    describe 'GET #edit' do
-      before do
-        @tag = create(:tag)
-      end
-
-      it 'populates the specified tutor' do
-        get :edit, params: { id: @tag }, format: :js, xhr: true
-        expect(assigns(:tag)).to eq(@tag)
-      end
-    end
-
-    describe 'PUT #update' do
-      before do
-        @tag = create(:tag)
-        @new_tag_attrs = attributes_for(:tag)
-      end
-
-      context 'with valid attributes' do
-        it 'saves the updated tag in the database' do
-          post :update, params: { id: @tag.id, tag: @new_tag_attrs }
-          expect(Tag.last.name).to eq(@new_tag_attrs[:name])
+      describe 'GET #index' do
+        it 'populates an array of all tags' do
+          tags = [create(:tag)]
+          get :index
+          expect(assigns(:tags)).to eq(tags)
         end
 
-        it 'redirects to the tags index view' do
-          post :update, params: { id: @tag.id, tag: @new_tag_attrs }
-          expect(response).to redirect_to(tags_path)
-        end
-      end
-    end
-
-    describe 'DELETE #destroy' do
-      it 'destroys the tag' do
-        tag = create(:tag)
-        expect { delete :destroy, params: { id: tag } }
-          .to change(Tag, :count).by(-1)
-      end
-
-      it 'destroys any created taggings' do
-        tag = create(:tag)
-        Tagging.create(tag_id: tag.id)
-        expect { delete :destroy, params: { id: tag } }
-          .to change(Tagging, :count).by(-1)
-      end
-
-      it 'redirects to the :index view' do
-        tag = create(:tag)
-        delete :destroy, params: { id: tag }
-        expect(response).to redirect_to tags_path
-      end
-    end
-
-    describe 'POST #create' do
-      before do
-        @tag_attrs = attributes_for(:tag)
-      end
-
-      context 'with valid attributes' do
-        it 'saves the new tag in the database' do
-          post :create, params: { tag: @tag_attrs }
-          expect(assigns(:tag)).to be_persisted
-        end
-
-        it 'assigns the newly created tag as @tag' do
-          post :create, params: { tag: @tag_attrs }
-          expect(assigns(:tag)).to be_a(Tag)
-        end
-
-        it 'renders the tag as json from an ajax request' do
-          post :create,
-               params: { tag: @tag_attrs.merge(name: 'blah') },
-               format: :json
-
-          expect(response.header['Content-Type']).to include 'application/json'
-          expect(JSON.parse(response.body)['name']).to eq 'blah'
-        end
-
-        it 'redirects to the tags#index page from html request' do
-          post :create, params: { tag: @tag_attrs }
-          expect(response).to redirect_to(tags_path)
+        it 'renders the :index view' do
+          get :index
+          expect(response).to render_template :index
         end
       end
 
-      context 'with invalid attributes' do
+      describe 'GET #show' do
         before do
-          allow_any_instance_of(Tag).to receive(:save) { false }
+          @tag = create(:tag)
+          @student = create(:student)
+          @tutor = create(:tutor)
+          Tagging.create(tag_id: @tag.id, student_id: @student.id)
+          Tagging.create(tag_id: @tag.id, tutor_id: @tutor.id)
         end
 
-        it 'assigns a newly created but unsaved tag as @tag' do
-          post :create, params: { tag: @tag_attrs }
-          expect(assigns(:tag)).to be_a_new(Tag)
+        it 'populates the tag, tutors, and students tagged' do
+          get :show, params: { id: @tag }, format: :js, xhr: true
+          expect(assigns(:tag)).to eq(@tag)
+          expect(assigns(:tagged_students)).to eq([@student])
+          expect(assigns(:tagged_tutors)).to eq([@tutor])
+        end
+      end
+
+      describe 'GET #edit' do
+        before do
+          @tag = create(:tag)
+        end
+
+        it 'populates the specified tutor' do
+          get :edit, params: { id: @tag }, format: :js, xhr: true
+          expect(assigns(:tag)).to eq(@tag)
+        end
+      end
+
+      describe 'PUT #update' do
+        before do
+          @tag = create(:tag)
+          @new_tag_attrs = attributes_for(:tag)
+        end
+
+        context 'with valid attributes' do
+          it 'saves the updated tag in the database' do
+            post :update, params: { id: @tag.id, tag: @new_tag_attrs }
+            expect(Tag.last.name).to eq(@new_tag_attrs[:name])
+          end
+
+          it 'redirects to the tags index view' do
+            post :update, params: { id: @tag.id, tag: @new_tag_attrs }
+            expect(response).to redirect_to(tags_path)
+          end
+        end
+      end
+
+      describe 'DELETE #destroy' do
+        it 'destroys the tag' do
+          tag = create(:tag)
+          expect { delete :destroy, params: { id: tag } }
+            .to change(Tag, :count).by(-1)
+        end
+
+        it 'destroys any created taggings' do
+          tag = create(:tag)
+          Tagging.create(tag_id: tag.id)
+          expect { delete :destroy, params: { id: tag } }
+            .to change(Tagging, :count).by(-1)
+        end
+
+        it 'redirects to the :index view' do
+          tag = create(:tag)
+          delete :destroy, params: { id: tag }
+          expect(response).to redirect_to tags_path
+        end
+      end
+
+      describe 'POST #create' do
+        before do
+          @tag_attrs = attributes_for(:tag)
+        end
+
+        context 'with valid attributes' do
+          it 'saves the new tag in the database' do
+            post :create, params: { tag: @tag_attrs }
+            expect(assigns(:tag)).to be_persisted
+          end
+
+          it 'assigns the newly created tag as @tag' do
+            post :create, params: { tag: @tag_attrs }
+            expect(assigns(:tag)).to be_a(Tag)
+          end
+
+          it 'renders the tag as json from an ajax request' do
+            post :create,
+                 params: { tag: @tag_attrs.merge(name: 'blah') },
+                 format: :json
+
+            expect(response.header['Content-Type'])
+              .to include 'application/json'
+            expect(JSON.parse(response.body)['name']).to eq 'blah'
+          end
+
+          it 'redirects to the tags#index page from html request' do
+            post :create, params: { tag: @tag_attrs }
+            expect(response).to redirect_to(tags_path)
+          end
+        end
+
+        context 'with invalid attributes' do
+          before do
+            allow_any_instance_of(Tag).to receive(:save) { false }
+          end
+
+          it 'assigns a newly created but unsaved tag as @tag' do
+            post :create, params: { tag: @tag_attrs }
+            expect(assigns(:tag)).to be_a_new(Tag)
+          end
         end
       end
     end

--- a/spec/controllers/tutor_comments_controller_spec.rb
+++ b/spec/controllers/tutor_comments_controller_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe TutorCommentsController, type: :controller do
   describe 'endpoints' do
     before do
-      sign_in_auth
+      user = User.new(role: 2)
+      sign_in_auth(user)
       @tutor = create(:tutor)
     end
 

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe WelcomeController, type: :controller do
   describe '#index' do
     describe 'when authenticated' do
       before do
-        sign_in_auth
+        user = User.new(role: 2)
+        sign_in_auth(user)
       end
 
       it 'renders the index template' do

--- a/spec/models/tutors_spec.rb
+++ b/spec/models/tutors_spec.rb
@@ -375,4 +375,63 @@ RSpec.describe Tutor, type: :model do
       end
     end
   end
+
+  describe '#of' do
+    before do
+      create(:affiliate, id: 1)
+      create(:affiliate, id: 2)
+
+      create(:coordinator, affiliate_id: 1, id: 1)
+
+      create(:tutor, affiliate_id: 1, id: 1)
+      create(:tutor, affiliate_id: 2, id: 2)
+
+      Tutor.find(1).coordinators << Coordinator.find(1)
+    end
+
+    describe 'when current user is tutor' do
+      before do
+        @user = User.new(tutor_id: 1,
+                         role: 0,
+                         email: 't@b.co',
+                         password: 'abcdef',
+                         password_confirmation: 'abcdef')
+      end
+
+      it 'returns no tutors' do
+        tutors = Student.of(@user)
+        expect(tutors).to be(nil)
+      end
+    end
+
+    describe 'when current user is coordinator' do
+      before do
+        @user = User.new(coordinator_id: 1,
+                         role: 1,
+                         email: 'c@b.co',
+                         password: 'abcdef',
+                         password_confirmation: 'abcdef')
+      end
+
+      it 'returns only tutors of coordinator affiliate' do
+        tutors = Tutor.of(@user)
+        expect(tutors.count).to eq(1)
+        expect(tutors.first.id).to eq(1)
+      end
+    end
+
+    describe 'when current user is admin' do
+      before do
+        @user = User.new(role: 2,
+                         email: 'a@b.co',
+                         password: 'abcdef',
+                         password_confirmation: 'abcdef')
+      end
+
+      it 'returns all tutors' do
+        tutors = Tutor.of(@user)
+        expect(tutors.count).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe User, type: :model do
       expect(@user.role).to eq(0)
       expect(@user.tutor?).to be_truthy
     end
-
-    it 'does not have any permission levels' do
-      expect(@user.coordinator_level?).to be_falsey
-      expect(@user.admin_level?).to be_falsey
-    end
   end
 
   context 'coordinator' do
@@ -25,11 +20,6 @@ RSpec.describe User, type: :model do
     it 'ensures coordinators have role 1' do
       expect(@user.role).to eq(1)
       expect(@user.coordinator?).to be_truthy
-    end
-
-    it 'correctly defines the access level for coordinators' do
-      expect(@user.coordinator_level?).to be_truthy
-      expect(@user.admin_level?).to be_falsey
     end
   end
 
@@ -42,10 +32,39 @@ RSpec.describe User, type: :model do
       expect(@user.role).to eq(2)
       expect(@user.admin?).to be_truthy
     end
+  end
 
-    it 'correctly defines the access level for coordinators' do
-      expect(@user.coordinator_level?).to be_truthy
-      expect(@user.admin_level?).to be_truthy
+  describe 'single_account_type' do
+    before(:each) do
+      @user = User.new(role: 0,
+                       email: 'a@b.co',
+                       password: 'abcdef',
+                       password_confirmation: 'abcdef')
+    end
+
+    describe 'when the user is associated with only a tutor' do
+      it 'validate' do
+        @user.tutor_id = 1
+        @user.save
+        expect(User.count).to eq(1)
+      end
+    end
+
+    describe 'when the user is associated with only a coordinator' do
+      it 'validate' do
+        @user.coordinator_id = 1
+        @user.save
+        expect(User.count).to eq(1)
+      end
+    end
+
+    describe 'when the user is associated with a tutor and coordinator' do
+      it 'does not validate' do
+        @user.tutor_id = 1
+        @user.coordinator_id = 1
+        @user.save
+        expect(User.count).to eq(0)
+      end
     end
   end
 end

--- a/spec/views/student/index_spec.rb
+++ b/spec/views/student/index_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'students/index.html.erb', type: :view do
   describe 'populate page and links' do
     before do
+      assign(:can_edit, true)
       @students = [create(:student, first_name: 'Joe', last_name: 'Lally',
                                     gender: 'male'),
                    create(:student, first_name: 'Tim', last_name: 'Bradley',

--- a/spec/views/tutors/index_spec.rb
+++ b/spec/views/tutors/index_spec.rb
@@ -2,17 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'tutors/index', type: :view do
   before(:each) do
-    @tutor = create(:tutor, cell_phone: '(999) 999-9999',
-                            home_phone: '(888) 888-8888')
-    assign(:tutors, [@tutor])
+    @tutor1 = create(:tutor)
+    @tutor2 = create(:tutor)
+    assign(:tutors, [@tutor1, @tutor2])
   end
 
   it 'renders a list of tutors' do
     render
-    expect(rendered).to match(@tutor.first_name)
-    expect(rendered).to match(@tutor.last_name)
-    expect(rendered).to match(/\(999\) 999-9999/)
-    expect(rendered).to match(/\(888\) 888-8888/)
-    expect(rendered).to match(@tutor.email_preferred)
+    expect(rendered).to match(@tutor1.first_name)
+    expect(rendered).to match(@tutor2.first_name)
   end
 end

--- a/spec/views/welcome/index_spec.rb
+++ b/spec/views/welcome/index_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'welcome/index.html.erb', type: :view do
   describe 'links' do
     before do
+      assign(:see_affiliates, true)
+      assign(:see_coordinators, true)
+      assign(:see_students, true)
+      assign(:see_tutors, true)
       render
     end
 


### PR DESCRIPTION
https://cs5500-jira.ccs.neu.edu/browse/LVM-434

This PR does 4 things at the application level:

1. It hides links that the user can't use (like the Tutors link on the Welcome page when logged in as a tutor)
2. It _scopes_ all calls for models for which the user should only see a subset using the new `.of` method on those models. This ensures that, when this is used, it will, for example, only show a tutor the students to which they are mapped.
3. It associates users with tutors and coordinators to make the above possible.
4. It blocks out certain controller actions (and even whole controllers) based on the user's role. Look for `before_do :ensure_admin!` at the top of certain controllers.

There are a few ways this needs to be tested, and I am asking _everyone_ to review this pull request. I don't want to merge it until it's been _approved_ by everyone.

1) Look through the code and look for controller actions that need to be blocked from certain roles.
2) Look through the code and look for ActiveRecord calls (ex: `Student.all`) that need to be scoped.
3) Move through the application with different privileges and try to break stuff. Eg. try to manually go to _localhost:3000/coordinators_ when logged in as a tutor.

One problem I had when writing this was that I wasn't exactly sure who should be allowed to do what. I know that this knowledge exists in the team, it's just poorly documented. So consider the nuanced stuff that you know about, like assessments or hours or whatever.

Thanks everyone!
Remember, security is important!